### PR TITLE
passport-jwt -> jwt standalone

### DIFF
--- a/config/passport/index.js
+++ b/config/passport/index.js
@@ -5,14 +5,15 @@ const { ExtractJwt, Strategy: JWTStrategy } = require('passport-jwt');
 require('dotenv').config();
 
 const mockUser = {
-    userId : 'user1',
+    id : 'user1',
     password : 'password1', 
+    status:'online',
 };
-function mockUserCheck(userId){
+function mockUserCheck(id){
     return new Promise((resolve, reject)=>{
         setTimeout(()=>{
-            if(userId === mockUser.userId){
-                resolve({userId : mockUser.userId});
+            if(id === mockUser.id){
+                resolve({id : mockUser.id});
             }
             else {
                 resolve();
@@ -20,8 +21,8 @@ function mockUserCheck(userId){
         }, 1000);
     })
 }
-function mockUserVerify(userId, password){
-    return (mockUser.userId === userId) && (mockUser.password === password);
+function mockUserVerify(id, password){
+    return (mockUser.id === id) && (mockUser.password === password);
 }
 
 //local strategy
@@ -43,6 +44,8 @@ const localVerify =  async (userId, password, done) => {
         done(e);
     }
 }
+
+/* jwt using passport-jwt depreciated
 
 //jwt strategy
 const cookieExtractor = (req)=>{
@@ -67,13 +70,14 @@ const jwtVerify = async (payload, done) => {
         done(e);
     }
 }
-
+*/
 
 module.exports = {
     initialize : () => {
         passport.use('local', new LocalStrategy(localConfig, localVerify));
-        passport.use('jwt', new JWTStrategy(jwtConfig, jwtVerify));
+        //passport.use('jwt', new JWTStrategy(jwtConfig, jwtVerify));
     },
+    /*
     authenticate : (req, res, next) => {
         return passport.authenticate('jwt', {session: false}, (err, user, info) => {
             if(err){
@@ -88,4 +92,5 @@ module.exports = {
             next();
         })(req,res,next);
     }
+    */
 }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ app.use(cookieParser());
 
 //passport config
 const passport = require('passport');
-const {initialize} = require('./passport/index');
+const {initialize} = require('./config/passport/index');
 app.use(passport.initialize());
 initialize();
 

--- a/src/app/Auth/authController.js
+++ b/src/app/Auth/authController.js
@@ -6,8 +6,7 @@ require('dotenv').config();
 
 const jwttest = async (req, res, next) => {
     try {
-        console.log(req.user);
-        res.status(200).json({msg: "you get the pizza"}); 
+        res.status(200).json({msg: `${req.user.id} got the pizza. he/she is ${req.user.status}.`}); 
 
     } catch (e) {
         console.error(e);
@@ -26,11 +25,9 @@ const signin = async (req, res, next) => {
                 next({status: 400, message: info.message});
                 return;
             }
-            req.login(user, {session: false}, (err) => {
-                const token = jwt.sign({id: user.userId}, process.env.JWT_KEY, {expiresIn: '1m'}); 
-                res.cookie('jwt',token);
-                res.status(200).json({message: "your token was generated"});
-            });
+            const token = jwt.sign({ id: user.id }, process.env.JWT_KEY, { expiresIn: '1m' });
+            res.cookie('jwt', token);
+            res.status(200).json({ message: "your token was generated" });
         })(req,res);        
     } catch (e) {
         console.error(e);
@@ -38,4 +35,15 @@ const signin = async (req, res, next) => {
     }
 }
 
-module.exports = { signin , jwttest }
+const signout = async (req, res, next) => {
+    try {
+        res.clearCookie('jwt');
+        res.status(200).redirect('/');
+    } catch (e) {
+        console.error(e);
+        next({status: 500, message: 'internal server error'});
+    }
+
+}
+
+module.exports = {jwttest, signin, signout };

--- a/src/app/Auth/authRoute.js
+++ b/src/app/Auth/authRoute.js
@@ -2,9 +2,10 @@ var express = require('express');
 var router = express.Router();
 const authController = require('./authController.js');
 const {wrapAsync} = require('../../../common/index');
-const {authenticate} =  require("../../../passport/index");
+const {authenticate} = require("../../middleware/auth");
 
-router.get('/jwttest',authenticate,wrapAsync(authController.jwttest));
+router.get('/jwttest',wrapAsync(authenticate),wrapAsync(authController.jwttest));
 router.post('/signin', wrapAsync(authController.signin));
+router.post('/logout', wrapAsync(authController.signout));
 
 module.exports = router;

--- a/src/middleware/auth.js
+++ b/src/middleware/auth.js
@@ -1,0 +1,70 @@
+const jwt = require('jsonwebtoken');
+
+require('dotenv').config();
+
+const {wrapAsync} = require('../../common/index');
+
+const mockUser = {
+    id : 'user1',
+    password : 'password1', 
+    status: 'onine',
+};
+function mockUserCheck(id){
+    return new Promise((resolve, reject)=>{
+        setTimeout(()=>{
+            if(id === mockUser.id){
+                resolve({...mockUser});
+            }
+            else {
+                resolve();
+            }
+        }, 1000);
+    })
+}
+function mockUserVerify(id, password){
+    return (mockUser.id === id) && (mockUser.password === password);
+}
+
+
+const cookieExtractor = (req)=>{
+    let token = null;
+    if (req&&req.cookies&&(req.cookies['jwt']!="")) token = req.cookies['jwt'];
+    return token;
+};
+
+const accessTokenVerify = (token) => {
+    let decoded = jwt.verify(token, process.env.JWT_KEY );     
+    return decoded;
+}
+
+const authenticate = async (req, res, next) => {
+    try {
+        let target = cookieExtractor(req);
+        if(target === null || target === undefined){
+            next({status: 401, message: "unauthorized"});
+            return;
+        }
+        let decoded = accessTokenVerify(target); 
+
+        let user = await mockUserCheck(decoded.id);
+        
+        if(!user){
+            next({status: 400, message: "user not exists"});
+            return;
+        }
+
+        req.user = {id: user.id, status: user.status};
+        next();
+
+    } catch (e) {
+        if(e.name=="TokenExpiredError"){
+            next({status: 401, message: "token has expired"});
+        }else {
+            next({status: 500, message: "internal server error"});
+        }
+    }
+}
+
+module.exports = {
+    authenticate
+}


### PR DESCRIPTION
passport-jwt를 이용하지 않는 방향으로 코드를 수정했습니다.

라우트 내에서 비동기를 사용하시는 경우 wrapAsync() 로 감싸주시면 됩니다.
인증이 필요한 라우트의 경우에는 middleware/auth/index.js 의 authenticate 를 wrapAsync로 감싸서 사용하면 됩니다. 